### PR TITLE
Add the ability to search by most used asset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,6 +116,10 @@ export const App = ({ onClose, onSelect, selectedAssets, tool, mode }: Props) =>
       newFilteredAssets.sort((a, b) => (b.title || b.originalFilename).localeCompare(a.title || a.originalFilename));
     }
 
+    if (sort === 'mostUsed') {
+      newFilteredAssets.sort((a, b) => (a.usedBy.length > b.usedBy.length ? -1 : 1));
+    }
+
     setFilteredAssets(newFilteredAssets);
 
     // Update selected assets so it does not include assets that are no longer visible

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -59,6 +59,7 @@ export const TopBar = ({ onSortChange, setSearchQuery, setViewType, viewType }: 
           onChange={(e) => onSortChange(e.currentTarget.value as SortOption)}
         >
           <option value="date">Latest first</option>
+          <option value="mostUsed">Most used</option>
           <option value="az">Filename A - Z</option>
           <option value="za">Filename Z - A</option>
         </Select>

--- a/src/types/SortOption.ts
+++ b/src/types/SortOption.ts
@@ -1,1 +1,1 @@
-export type SortOption = 'date' | 'az' | 'za';
+export type SortOption = 'date' | 'az' | 'za' | 'mostUsed';


### PR DESCRIPTION
I think this would be a beneficial addition.

On some sites I re-use the same asset multiple times. This filter provides quick access to the most commonly used assets (see screenshot for example):

<img width="1624" alt="Screenshot 2022-12-05 at 15 57 37" src="https://user-images.githubusercontent.com/104832583/205684342-d0e98026-d04b-4599-b604-a3e14faf343f.png">

